### PR TITLE
add: monochrome icon for Android 13+ devices.

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
Previews:

![image](https://github.com/Radiokot/photoprism-android-client/assets/23419678/c70f8ebf-7131-48bc-a5f7-110b5454a5bc)
![image](https://github.com/Radiokot/photoprism-android-client/assets/23419678/0a14f390-8f3c-418f-800e-83e7e1a8dbf2)
