### PR TITLE
fix search on android TV no more mouse needed: update focus navigation in layout

### DIFF
--- a/app/src/main/java/ua/com/radiokot/photoprism/features/gallery/search/view/GallerySearchBarView.kt
+++ b/app/src/main/java/ua/com/radiokot/photoprism/features/gallery/search/view/GallerySearchBarView.kt
@@ -55,10 +55,7 @@ class GallerySearchBarView(
 
     private fun initBar() = with(searchBar) {
         setHint(
-            if (tvDetector.isRunningOnTv)
-                R.string.use_mouse_to_search_the_library
-            else
-                R.string.search_the_library
+            R.string.search_the_library
         )
 
         textView.ellipsize = TextUtils.TruncateAt.END

--- a/app/src/main/res/layout/view_gallery_search_config.xml
+++ b/app/src/main/res/layout/view_gallery_search_config.xml
@@ -54,6 +54,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="10dp"
+                android:nextFocusDown="@+id/reset_button"
                 android:text="@string/only_favorite_content"
                 android:textAppearance="@style/TextAppearance.Material3.LabelLarge" />
 
@@ -75,6 +76,8 @@
         android:layout_marginStart="16dp"
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="8dp"
+        android:nextFocusUp="@id/only_favorite_switch"
+        android:nextFocusRight="@id/search_button"
         android:text="@string/reset_search"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/search_button"
@@ -88,6 +91,8 @@
         android:layout_marginStart="8dp"
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="8dp"
+        android:nextFocusUp="@id/only_favorite_switch"
+        android:nextFocusLeft="@id/reset_button"
         android:text="@string/apply_search"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -29,7 +29,6 @@
     <string name="failed_to_load_the_thumbnail">缩略图加载失败</string>
     <string name="today">今日</string>
     <string name="search_the_library">在图库中搜索</string>
-    <string name="use_mouse_to_search_the_library">在图库中搜索（使用鼠标）</string>
     <string name="enter_the_query">输入关键字搜索</string>
     <string name="media_type">类型</string>
     <string name="apply_search">应用</string>

--- a/app/src/main/res/values-b+zh+Hant/strings.xml
+++ b/app/src/main/res/values-b+zh+Hant/strings.xml
@@ -29,7 +29,6 @@
     <string name="failed_to_load_the_thumbnail">縮圖載入失敗</string>
     <string name="today">今天</string>
     <string name="search_the_library">在相簿中搜尋</string>
-    <string name="use_mouse_to_search_the_library">在相簿中搜尋（使用滑鼠）</string>
     <string name="enter_the_query">輸入關鍵字搜索</string>
     <string name="media_type">類別</string>
     <string name="apply_search">應用</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -30,7 +30,6 @@
     <string name="failed_to_load_the_thumbnail">Nepodařilo se načíst miniatury</string>
     <string name="today">Dnes</string>
     <string name="search_the_library">Vyhledávání v knihovně</string>
-    <string name="use_mouse_to_search_the_library">Vyhledávání v knihovně (použíjte myš)</string>
     <string name="enter_the_query">Zadejte dotaz</string>
     <string name="media_type">Typ</string>
     <string name="apply_search">Použít</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -29,7 +29,6 @@
     <string name="failed_to_load_the_thumbnail">Konnte Vorschaubild nicht laden</string>
     <string name="today">Heute</string>
     <string name="search_the_library">Durchsuchen</string>
-    <string name="use_mouse_to_search_the_library">Durchsuchen (Maus benutzen)</string>
     <string name="enter_the_query">Suchanfrage eingeben</string>
     <string name="media_type">Typ</string>
     <string name="apply_search">Anwenden</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -29,7 +29,6 @@
     <string name="failed_to_load_the_thumbnail">αδυναμία φόρτωσης προεπισκόπησης</string>
     <string name="today">σήμερα</string>
     <string name="search_the_library">αναζήτηση στη βιβλιοθήκη</string>
-    <string name="use_mouse_to_search_the_library">αναζήτηση στη βιβλιοθήκη (χρησιμοποιήστε το ποντίκι)</string>
     <string name="enter_the_query">εισαγωγή όρου αναζήτησης</string>
     <string name="media_type">τύπος</string>
     <string name="apply_search">εφαρμογή</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -30,7 +30,6 @@
     <string name="failed_to_load_the_thumbnail">Fallo al cargar la miniatura</string>
     <string name="today">Hoy</string>
     <string name="search_the_library">Buscar en la biblioteca</string>
-    <string name="use_mouse_to_search_the_library">Buscar en la biblioteca (usar ratón)</string>
     <string name="enter_the_query">Introduce la consulta</string>
     <string name="media_type">Tipo</string>
     <string name="apply_search">Aplicar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -30,7 +30,6 @@
     <string name="failed_to_load_the_thumbnail">Impossible de charger la miniature</string>
     <string name="today">Aujourd\'hui</string>
     <string name="search_the_library">Rechercher dans la bibliothèque</string>
-    <string name="use_mouse_to_search_the_library">Rechercher dans la bibliothèque (utiliser la souris)</string>
     <string name="enter_the_query">Entrer la requête</string>
     <string name="media_type">Type</string>
     <string name="apply_search">Appliquer</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -29,7 +29,6 @@
     <string name="failed_to_load_the_thumbnail">Caricamento della miniatura non riuscito</string>
     <string name="today">Oggi</string>
     <string name="search_the_library">Cerca nella libreria</string>
-    <string name="use_mouse_to_search_the_library">Cerca nella libreria (usa il mouse)</string>
     <string name="enter_the_query">Cerca</string>
     <string name="media_type">Tipo</string>
     <string name="apply_search">Applica</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -30,7 +30,6 @@
     <string name="failed_to_load_the_thumbnail">Nie udało się załadować miniatury</string>
     <string name="today">Dziś</string>
     <string name="search_the_library">Szukaj w bibliotece</string>
-    <string name="use_mouse_to_search_the_library">Szukaj w bibliotece (użyj myszy)</string>
     <string name="enter_the_query">Wpisz zapytanie</string>
     <string name="media_type">Typ</string>
     <string name="apply_search">Zastosuj</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -29,7 +29,6 @@
     <string name="failed_to_load_the_thumbnail">Не удалось загрузить миниатюру</string>
     <string name="today">Сегодня</string>
     <string name="search_the_library">Поиск в библиотеке</string>
-    <string name="use_mouse_to_search_the_library">Поиск в библиотеке (используйте мышь)</string>
     <string name="enter_the_query">Введите запрос</string>
     <string name="media_type">Тип</string>
     <string name="apply_search">Применить</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -29,7 +29,6 @@
     <string name="failed_to_load_the_thumbnail">Küçük resim yüklenemedi</string>
     <string name="today">Bugün</string>
     <string name="search_the_library">Kitaplıkta ara</string>
-    <string name="use_mouse_to_search_the_library">Kitaplıkta ara (fareyi kullan)</string>
     <string name="enter_the_query">Sorgu gir</string>
     <string name="media_type">Tür</string>
     <string name="apply_search">Uygula</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -29,7 +29,6 @@
     <string name="failed_to_load_the_thumbnail">Не вдалося завантажити мініатюру</string>
     <string name="today">Сьогодні</string>
     <string name="search_the_library">Пошук у бібліотеці</string>
-    <string name="use_mouse_to_search_the_library">Пошук у бібліотеці (скористуйтеся мишкою)</string>
     <string name="enter_the_query">Введіть запит</string>
     <string name="media_type">Тип</string>
     <string name="apply_search">Застосувати</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,7 +31,6 @@
     <string name="failed_to_load_the_thumbnail">Failed to load the thumbnail</string>
     <string name="today">Today</string>
     <string name="search_the_library">Search the library</string>
-    <string name="use_mouse_to_search_the_library">Search the library (use the mouse)</string>
     <string name="enter_the_query">Enter the query</string>
     <string name="media_type">Type</string>
     <string name="apply_search">Apply</string>


### PR DESCRIPTION
fix search on android TV: update focus navigation in layout and refactor search-related strings and 

- GallerySearchBarView.kt: Removed TV-specific hint text logic as the search view is now fully navigable.
- view_gallery_search_config.xml: Improved focus navigation for Android TV. Added `nextFocusDown` to the last switch to reach buttons, and `nextFocusUp` from buttons to return to the list. Also added horizontal navigation between Reset and Apply buttons.
- strings.xml: Removed unused `use_fix search on android tv: Refactor search-related strings and update focus navigation in layout