### PR TITLE
Add face search match operator

### DIFF
--- a/app/db-schema/ua.com.radiokot.photoprism.db.AppDatabase/8.json
+++ b/app/db-schema/ua.com.radiokot.photoprism.db.AppDatabase/8.json
@@ -1,0 +1,138 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 8,
+    "identityHash": "e1579598677920b28499acbfcc702fac",
+    "entities": [
+      {
+        "tableName": "bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `position` REAL NOT NULL, `name` TEXT NOT NULL, `user_query` TEXT, `media_types` TEXT, `include_private` INTEGER NOT NULL, `only_favorite` INTEGER NOT NULL DEFAULT 0, `album_uid` TEXT, `person_ids` TEXT NOT NULL DEFAULT '[]', `person_filter_operator` TEXT NOT NULL DEFAULT 'ALL', PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userQuery",
+            "columnName": "user_query",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediaTypes",
+            "columnName": "media_types",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "includePrivate",
+            "columnName": "include_private",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "onlyFavorite",
+            "columnName": "only_favorite",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "albumUid",
+            "columnName": "album_uid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "personIds",
+            "columnName": "person_ids",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "personFilterOperator",
+            "columnName": "person_filter_operator",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'ALL'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bookmarks_position",
+            "unique": false,
+            "columnNames": [
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bookmarks_position` ON `${TABLE_NAME}` (`position`)"
+          }
+        ]
+      },
+      {
+        "tableName": "memories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`searchQuery` TEXT NOT NULL, `is_seen` INTEGER NOT NULL, `created_at_ms` INTEGER NOT NULL, `preview_hash` TEXT NOT NULL, `type_data` TEXT NOT NULL, PRIMARY KEY(`searchQuery`))",
+        "fields": [
+          {
+            "fieldPath": "searchQuery",
+            "columnName": "searchQuery",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSeen",
+            "columnName": "is_seen",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAtMs",
+            "columnName": "created_at_ms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailHash",
+            "columnName": "preview_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "typeData",
+            "columnName": "type_data",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "searchQuery"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e1579598677920b28499acbfcc702fac')"
+    ]
+  }
+}

--- a/app/src/main/java/ua/com/radiokot/photoprism/db/AppDatabase.kt
+++ b/app/src/main/java/ua/com/radiokot/photoprism/db/AppDatabase.kt
@@ -10,7 +10,7 @@ import ua.com.radiokot.photoprism.features.gallery.data.model.SearchBookmarksDbE
 import ua.com.radiokot.photoprism.features.gallery.data.storage.SearchBookmarksDbDao
 
 @Database(
-    version = 7,
+    version = 8,
     entities = [
         SearchBookmarksDbEntity::class,
         MemoryDbEntity::class,

--- a/app/src/main/java/ua/com/radiokot/photoprism/di/DbModules.kt
+++ b/app/src/main/java/ua/com/radiokot/photoprism/di/DbModules.kt
@@ -41,6 +41,9 @@ val appDbModule = module {
                         "`media_types`=?",
                         arrayOf("[]")
                     )
+                },
+                roomMigration(from = 7, to = 8) {
+                    execSQL("ALTER TABLE `bookmarks` ADD COLUMN `person_filter_operator` TEXT NOT NULL DEFAULT 'ALL'")
                 }
             )
             .build()

--- a/app/src/main/java/ua/com/radiokot/photoprism/features/gallery/data/model/SearchBookmark.kt
+++ b/app/src/main/java/ua/com/radiokot/photoprism/features/gallery/data/model/SearchBookmark.kt
@@ -20,6 +20,9 @@ data class SearchBookmark(
                 ?.toSet(),
             albumUid = dbEntity.albumUid,
             personIds = dbEntity.personIds.toSet(),
+            personFilterOperator = SearchConfig.PersonFilterOperator.valueOf(
+                dbEntity.personFilterOperator
+            ),
             beforeLocal = null,
             afterLocal = null,
             userQuery = dbEntity.userQuery ?: "",
@@ -38,6 +41,7 @@ data class SearchBookmark(
         onlyFavorite = searchConfig.onlyFavorite,
         albumUid = searchConfig.albumUid,
         personIds = searchConfig.personIds.toList(),
+        personFilterOperator = searchConfig.personFilterOperator.name,
     )
 
     override fun compareTo(other: SearchBookmark): Int = position.compareTo(other.position)

--- a/app/src/main/java/ua/com/radiokot/photoprism/features/gallery/data/model/SearchBookmarksDbEntity.kt
+++ b/app/src/main/java/ua/com/radiokot/photoprism/features/gallery/data/model/SearchBookmarksDbEntity.kt
@@ -30,4 +30,6 @@ data class SearchBookmarksDbEntity(
     val albumUid: String?,
     @ColumnInfo("person_ids", defaultValue = "[]")
     val personIds: List<String>,
+    @ColumnInfo("person_filter_operator", defaultValue = "'ALL'")
+    val personFilterOperator: String,
 )

--- a/app/src/main/java/ua/com/radiokot/photoprism/features/gallery/data/model/SearchConfig.kt
+++ b/app/src/main/java/ua/com/radiokot/photoprism/features/gallery/data/model/SearchConfig.kt
@@ -16,10 +16,11 @@ data class SearchConfig(
     val albumUid: String?,
     /**
      * A set of [Person.id] which may be subjects or faces,
-     * to find only items with them together.
+     * to find only items with all/any of them.
      * If empty, no subject/face filters are applied.
      */
     val personIds: Set<String>,
+    val personFilterOperator: PersonFilterOperator = PersonFilterOperator.ALL,
     /**
      * Local date to find media taken before it.
      * Local post filtering by [GalleryMedia.takenAtLocal]
@@ -129,13 +130,13 @@ data class SearchConfig(
             val subjectUids = personIds
                 .filter(Person::isSubjectUid)
             if (subjectUids.isNotEmpty()) {
-                queryBuilder.append(" subject:${subjectUids.joinToString("&")}")
+                queryBuilder.append(" subject:${subjectUids.joinToString(personFilterOperator.photoPrismOperator)}")
             }
 
             val faceIds = personIds
                 .filter(Person::isFaceId)
             if (faceIds.isNotEmpty()) {
-                queryBuilder.append(" face:${faceIds.joinToString("&")}")
+                queryBuilder.append(" face:${faceIds.joinToString(personFilterOperator.photoPrismOperator)}")
             }
         }
 
@@ -150,6 +151,7 @@ data class SearchConfig(
             mediaTypes = null,
             albumUid = null,
             personIds = emptySet(),
+            personFilterOperator = PersonFilterOperator.ALL,
             beforeLocal = null,
             afterLocal = null,
             userQuery = "",
@@ -176,5 +178,12 @@ data class SearchConfig(
                 userQuery = base.userQuery + " label:$labelSlug",
                 includePrivate = true,
             )
+    }
+
+    enum class PersonFilterOperator(
+        val photoPrismOperator: String,
+    ) {
+        ALL("&"),
+        ANY("|"),
     }
 }

--- a/app/src/main/java/ua/com/radiokot/photoprism/features/gallery/data/storage/SearchConfigPersistenceOnPrefs.kt
+++ b/app/src/main/java/ua/com/radiokot/photoprism/features/gallery/data/storage/SearchConfigPersistenceOnPrefs.kt
@@ -54,6 +54,8 @@ class SearchConfigPersistenceOnPrefs(
         val albumUid: String?,
         @JsonProperty("pe")
         val personIds: Set<String>,
+        @JsonProperty("po")
+        val personFilterOperator: SearchConfig.PersonFilterOperator?,
     ) {
         constructor(source: SearchConfig) : this(
             userQuery = source.userQuery,
@@ -63,6 +65,7 @@ class SearchConfigPersistenceOnPrefs(
             onlyFavorite = source.onlyFavorite,
             albumUid = source.albumUid,
             personIds = source.personIds,
+            personFilterOperator = source.personFilterOperator,
         )
 
         fun toSource() = SearchConfig(
@@ -76,6 +79,8 @@ class SearchConfigPersistenceOnPrefs(
             afterLocal = null,
             albumUid = albumUid,
             personIds = personIds,
+            personFilterOperator = personFilterOperator
+                ?: SearchConfig.PersonFilterOperator.ALL,
         )
     }
 }

--- a/app/src/main/java/ua/com/radiokot/photoprism/features/gallery/search/logic/JsonSearchBookmarksBackup.kt
+++ b/app/src/main/java/ua/com/radiokot/photoprism/features/gallery/search/logic/JsonSearchBookmarksBackup.kt
@@ -37,7 +37,7 @@ class JsonSearchBookmarksBackup(
             jsonObjectMapper.readValue(input, BookmarksBackup::class.java)
 
         return when (val version = backup.version) {
-            VERSION ->
+            VERSION, 3 ->
                 readBackupData(backup.data).bookmarks.map(BackupData.Bookmark::toSource)
 
             2 ->
@@ -100,6 +100,8 @@ class JsonSearchBookmarksBackup(
             val albumUid: String?,
             @JsonProperty("pe")
             val personIds: Set<String>,
+            @JsonProperty("po")
+            val personFilterOperator: SearchConfig.PersonFilterOperator?,
         ) {
             constructor(source: SearchBookmark) : this(
                 id = source.id,
@@ -112,6 +114,7 @@ class JsonSearchBookmarksBackup(
                 onlyFavorite = source.searchConfig.onlyFavorite,
                 albumUid = source.searchConfig.albumUid,
                 personIds = source.searchConfig.personIds,
+                personFilterOperator = source.searchConfig.personFilterOperator,
             )
 
             fun toSource() = SearchBookmark(
@@ -129,6 +132,8 @@ class JsonSearchBookmarksBackup(
                     afterLocal = null,
                     albumUid = albumUid,
                     personIds = personIds,
+                    personFilterOperator = personFilterOperator
+                        ?: SearchConfig.PersonFilterOperator.ALL,
                 )
             )
         }
@@ -224,6 +229,6 @@ class JsonSearchBookmarksBackup(
     }
 
     private companion object {
-        private const val VERSION = 3
+        private const val VERSION = 4
     }
 }

--- a/app/src/main/java/ua/com/radiokot/photoprism/features/gallery/search/people/view/GallerySearchConfigPeopleView.kt
+++ b/app/src/main/java/ua/com/radiokot/photoprism/features/gallery/search/people/view/GallerySearchConfigPeopleView.kt
@@ -14,6 +14,7 @@ import ua.com.radiokot.photoprism.databinding.ViewGallerySearchConfigPeopleBindi
 import ua.com.radiokot.photoprism.extension.ensureItemIsVisible
 import ua.com.radiokot.photoprism.extension.kLogger
 import ua.com.radiokot.photoprism.extension.subscribe
+import ua.com.radiokot.photoprism.features.gallery.data.model.SearchConfig
 import ua.com.radiokot.photoprism.features.gallery.search.people.view.model.GallerySearchPeopleViewModel
 import ua.com.radiokot.photoprism.features.people.view.PeopleSelectionActivity
 import ua.com.radiokot.photoprism.features.people.view.model.SelectablePersonListItem
@@ -61,6 +62,25 @@ class GallerySearchConfigPeopleView(
             viewModel.onSeeAllClicked()
         }
 
+        view.personFilterOperatorToggle.addOnButtonCheckedListener { _, checkedId, isChecked ->
+            if (!isChecked) {
+                return@addOnButtonCheckedListener
+            }
+
+            viewModel.onPersonFilterOperatorClicked(
+                when (checkedId) {
+                    view.personFilterOperatorAllButton.id ->
+                        SearchConfig.PersonFilterOperator.ALL
+
+                    view.personFilterOperatorAnyButton.id ->
+                        SearchConfig.PersonFilterOperator.ANY
+
+                    else ->
+                        return@addOnButtonCheckedListener
+                }
+            )
+        }
+
         subscribeToState()
         subscribeToEvents()
 
@@ -100,6 +120,18 @@ class GallerySearchConfigPeopleView(
         }
 
         viewModel.isViewVisible.subscribe(this, view.root::isVisible::set)
+
+        viewModel.selectedPersonFilterOperator.observe(this) { operator ->
+            view.personFilterOperatorToggle.check(
+                when (operator) {
+                    SearchConfig.PersonFilterOperator.ALL ->
+                        view.personFilterOperatorAllButton.id
+
+                    SearchConfig.PersonFilterOperator.ANY ->
+                        view.personFilterOperatorAnyButton.id
+                }
+            )
+        }
     }
 
     private fun subscribeToEvents() = viewModel.events.subscribe(this) { event ->

--- a/app/src/main/java/ua/com/radiokot/photoprism/features/gallery/search/people/view/model/GallerySearchPeopleViewModel.kt
+++ b/app/src/main/java/ua/com/radiokot/photoprism/features/gallery/search/people/view/model/GallerySearchPeopleViewModel.kt
@@ -8,6 +8,7 @@ import io.reactivex.rxjava3.subjects.PublishSubject
 import ua.com.radiokot.photoprism.extension.autoDispose
 import ua.com.radiokot.photoprism.extension.kLogger
 import ua.com.radiokot.photoprism.extension.observeOnMain
+import ua.com.radiokot.photoprism.features.gallery.data.model.SearchConfig
 import ua.com.radiokot.photoprism.features.gallery.logic.MediaPreviewUrlFactory
 import ua.com.radiokot.photoprism.features.gallery.search.data.storage.SearchPreferences
 import ua.com.radiokot.photoprism.features.people.data.model.Person
@@ -30,6 +31,9 @@ class GallerySearchPeopleViewModel(
      * Non-null set of the selected person IDs, **empty** if nothing is selected.
      */
     val selectedPersonIds = MutableLiveData<Set<String>>(emptySet())
+    val selectedPersonFilterOperator = MutableLiveData(
+        SearchConfig.PersonFilterOperator.ALL
+    )
 
     init {
         subscribeToRepository()
@@ -138,6 +142,15 @@ class GallerySearchPeopleViewModel(
                 selectedPersonIds.value = currentlySelectedPersonIds + id
             }
         }
+    }
+
+    fun onPersonFilterOperatorClicked(operator: SearchConfig.PersonFilterOperator) {
+        log.debug {
+            "onPersonFilterOperatorClicked(): operator_clicked:" +
+                    "\noperator=$operator"
+        }
+
+        selectedPersonFilterOperator.value = operator
     }
 
     fun onReloadPeopleClicked() {

--- a/app/src/main/java/ua/com/radiokot/photoprism/features/gallery/search/view/model/GallerySearchViewModel.kt
+++ b/app/src/main/java/ua/com/radiokot/photoprism/features/gallery/search/view/model/GallerySearchViewModel.kt
@@ -64,6 +64,7 @@ class GallerySearchViewModel(
     val onlyFavorite = MutableLiveData<Boolean>()
     private val selectedAlbumUid = albumsViewModel.selectedAlbumUid
     private val selectedPersonIds = peopleViewModel.selectedPersonIds
+    private val selectedPersonFilterOperator = peopleViewModel.selectedPersonFilterOperator
 
     init {
         val updateApplyButtonEnabled = { _: Any? ->
@@ -76,6 +77,7 @@ class GallerySearchViewModel(
         onlyFavorite.observeForever(updateApplyButtonEnabled)
         selectedAlbumUid.observeForever(updateApplyButtonEnabled)
         selectedPersonIds.observeForever(updateApplyButtonEnabled)
+        selectedPersonFilterOperator.observeForever(updateApplyButtonEnabled)
 
         subscribeToBookmarks()
 
@@ -92,6 +94,8 @@ class GallerySearchViewModel(
                     || onlyFavorite.value != searchDefaults.onlyFavorite
                     || selectedAlbumUid.value != searchDefaults.albumUid
                     || selectedPersonIds.value != searchDefaults.personIds
+                    || (selectedPersonIds.value!!.isNotEmpty()
+                            && selectedPersonFilterOperator.value != searchDefaults.personFilterOperator)
         }
 
     private val areBookmarksCurrentlyMoving = MutableLiveData(false)
@@ -256,6 +260,7 @@ class GallerySearchViewModel(
         onlyFavorite.value = searchConfig.onlyFavorite
         selectedAlbumUid.value = searchConfig.albumUid
         selectedPersonIds.value = searchConfig.personIds
+        selectedPersonFilterOperator.value = searchConfig.personFilterOperator
     }
 
     fun updateExternalData(force: Boolean = false) {
@@ -290,11 +295,17 @@ class GallerySearchViewModel(
             "The search can only be applied while configuring"
         }
 
+        val personIds = selectedPersonIds.value!!
         val config = SearchConfig(
             mediaTypes = selectedMediaTypes.value,
             userQuery = userQuery.value!!.trim(),
             albumUid = selectedAlbumUid.value,
-            personIds = selectedPersonIds.value!!,
+            personIds = personIds,
+            personFilterOperator = if (personIds.isNotEmpty()) {
+                selectedPersonFilterOperator.value!!
+            } else {
+                searchDefaults.personFilterOperator
+            },
             beforeLocal = null,
             afterLocal = null,
             includePrivate = includePrivateContent.value == true,

--- a/app/src/main/res/layout/view_gallery_search_config_people.xml
+++ b/app/src/main/res/layout/view_gallery_search_config_people.xml
@@ -46,6 +46,50 @@
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         tools:listitem="@layout/list_item_gallery_search_person" />
 
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="8dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="@string/match_people"
+            android:textAppearance="@style/TextAppearance.Material3.LabelLarge" />
+
+        <com.google.android.material.button.MaterialButtonToggleGroup
+            android:id="@+id/person_filter_operator_toggle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:selectionRequired="true"
+            app:singleSelection="true">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/person_filter_operator_all_button"
+                style="@style/Widget.Material3.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="36dp"
+                android:minWidth="64dp"
+                android:minHeight="0dp"
+                android:paddingVertical="0dp"
+                android:text="@string/match_all_people" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/person_filter_operator_any_button"
+                style="@style/Widget.Material3.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="36dp"
+                android:minWidth="64dp"
+                android:minHeight="0dp"
+                android:paddingVertical="0dp"
+                android:text="@string/match_any_people" />
+        </com.google.android.material.button.MaterialButtonToggleGroup>
+    </LinearLayout>
+
     <TextView
         android:id="@+id/loading_people_text_view"
         android:layout_width="match_parent"

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -124,6 +124,9 @@
     <string name="loading_people_progress">@string/loading_data_progress</string>
     <string name="reload_people">@string/reload</string>
     <string name="no_people_found">Nebyly nalezeny žádné osoby</string>
+    <string name="match_people">Shoda</string>
+    <string name="match_all_people">Všichni</string>
+    <string name="match_any_people">Kdokoli</string>
     <string name="reload">Znovu načíst</string>
     <string name="loading_data_progress">Načítání dat…</string>
     <string name="search_preferences">Hledání</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -123,6 +123,9 @@
     <string name="loading_people_progress">@string/loading_data_progress</string>
     <string name="reload_people">@string/reload</string>
     <string name="no_people_found">Keine Personen gefunden</string>
+    <string name="match_people">Übereinstimmung</string>
+    <string name="match_all_people">Alle</string>
+    <string name="match_any_people">Beliebig</string>
     <string name="reload">Neu laden</string>
     <string name="loading_data_progress">Lade Daten…</string>
     <string name="search_preferences">Suche</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -123,6 +123,9 @@
     <string name="loading_people_progress">@string/loading_data_progress</string>
     <string name="reload_people">@string/reload</string>
     <string name="no_people_found">Δεν βρέθηκαν άτομα</string>
+    <string name="match_people">Ταίριασμα</string>
+    <string name="match_all_people">Όλα</string>
+    <string name="match_any_people">Οποιοδήποτε</string>
     <string name="reload">Φορτώστε ξανά</string>
     <string name="loading_data_progress">φόρτωση δεδομένων…</string>
     <string name="search_preferences">αναζήτηση</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -124,6 +124,9 @@
     <string name="loading_people_progress">@string/loading_data_progress</string>
     <string name="reload_people">@string/reload</string>
     <string name="no_people_found">No se encontró gente</string>
+    <string name="match_people">Coincidencia</string>
+    <string name="match_all_people">Todas</string>
+    <string name="match_any_people">Cualquiera</string>
     <string name="reload">Recargar</string>
     <string name="loading_data_progress">Cargando datos</string>
     <string name="search_preferences">Buscar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -124,6 +124,9 @@
     <string name="loading_people_progress">@string/loading_data_progress</string>
     <string name="reload_people">@string/reload</string>
     <string name="no_people_found">Aucune personne trouvé</string>
+    <string name="match_people">Correspondance</string>
+    <string name="match_all_people">Tous</string>
+    <string name="match_any_people">Au moins un</string>
     <string name="reload">Recharger</string>
     <string name="loading_data_progress">Chargement des données…</string>
     <string name="search_preferences">Rechercher</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -123,6 +123,9 @@
     <string name="loading_people_progress">@string/loading_data_progress</string>
     <string name="reload_people">@string/reload</string>
     <string name="no_people_found">Nessuna persona trovata</string>
+    <string name="match_people">Corrispondenza</string>
+    <string name="match_all_people">Tutte</string>
+    <string name="match_any_people">Qualsiasi</string>
     <string name="reload">Ricarica</string>
     <string name="loading_data_progress">Caricamento dati…</string>
     <string name="search_preferences">Cerca</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -122,6 +122,9 @@
     <string name="loading_people_progress">@string/loading_data_progress</string>
     <string name="reload_people">@string/reload</string>
     <string name="no_people_found">Osoby nie znalezione</string>
+    <string name="match_people">Dopasowanie</string>
+    <string name="match_all_people">Wszyscy</string>
+    <string name="match_any_people">Dowolna</string>
     <string name="reload">Odśwież</string>
     <string name="loading_data_progress">Ładowanie danych…</string>
     <string name="search_preferences">Wyszukiwanie</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -123,6 +123,9 @@
     <string name="loading_people_progress">@string/loading_data_progress</string>
     <string name="reload_people">@string/reload</string>
     <string name="no_people_found">Люди не найдены</string>
+    <string name="match_people">Совпадение</string>
+    <string name="match_all_people">Все</string>
+    <string name="match_any_people">Любой</string>
     <string name="reload">Перезагрузить</string>
     <string name="loading_data_progress">Загрузка данных…</string>
     <string name="search_preferences">Поиск</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -123,6 +123,9 @@
     <string name="loading_people_progress">@string/loading_data_progress</string>
     <string name="reload_people">@string/reload</string>
     <string name="no_people_found">Kimse bulunamadı</string>
+    <string name="match_people">Eşleşme</string>
+    <string name="match_all_people">Tümü</string>
+    <string name="match_any_people">Herhangi</string>
     <string name="reload">Tekrar yükle</string>
     <string name="loading_data_progress">Veri yükleniyor…</string>
     <string name="search_preferences">Arama</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -123,6 +123,9 @@
     <string name="loading_people_progress">@string/loading_data_progress</string>
     <string name="reload_people">@string/reload</string>
     <string name="no_people_found">Людей не знайдено</string>
+    <string name="match_people">Збіг</string>
+    <string name="match_all_people">Усі</string>
+    <string name="match_any_people">Будь-хто</string>
     <string name="reload">Перезавантажити</string>
     <string name="loading_data_progress">Завантаження даних…</string>
     <string name="search_preferences">Пошук</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,9 @@
     <string name="loading_people_progress">@string/loading_data_progress</string>
     <string name="reload_people">@string/reload</string>
     <string name="no_people_found">No people found</string>
+    <string name="match_people">Match</string>
+    <string name="match_all_people">All</string>
+    <string name="match_any_people">Any</string>
     <string name="reload">Reload</string>
     <string name="loading_data_progress">Loading data…</string>
     <string name="search_preferences">Search</string>

--- a/app/src/test/java/ua/com/radiokot/photoprism/JsonSearchBookmarkBackupTest.kt
+++ b/app/src/test/java/ua/com/radiokot/photoprism/JsonSearchBookmarkBackupTest.kt
@@ -2,11 +2,13 @@ package ua.com.radiokot.photoprism
 
 import com.fasterxml.jackson.module.kotlin.jsonMapper
 import okio.IOException
+import org.junit.AfterClass
 import org.junit.Assert
 import org.junit.BeforeClass
 import org.junit.Test
 import org.koin.core.component.KoinComponent
 import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
 import ua.com.radiokot.photoprism.features.gallery.data.model.GalleryMedia
 import ua.com.radiokot.photoprism.features.gallery.data.model.SearchBookmark
 import ua.com.radiokot.photoprism.features.gallery.data.model.SearchConfig
@@ -23,6 +25,12 @@ class JsonSearchBookmarkBackupTest : KoinComponent {
             startKoin {
                 modules(galleryFeatureModule)
             }
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDownKoin() {
+            stopKoin()
         }
 
         val BOOKMARKS = listOf(
@@ -72,6 +80,7 @@ class JsonSearchBookmarkBackupTest : KoinComponent {
                     onlyFavorite = true,
                     albumUid = null,
                     personIds = setOf("p2132523232", "pwr9hh8ef9w3"),
+                    personFilterOperator = SearchConfig.PersonFilterOperator.ANY,
                 )
             ),
         )
@@ -92,7 +101,7 @@ class JsonSearchBookmarkBackupTest : KoinComponent {
         val outputJson = String(outputStream.toByteArray(), Charsets.UTF_8)
 
         Assert.assertEquals(
-            """{"v":3,"d":{"b":[{"id":1,"p":1.0,"n":"My camera","q":"quality:3 oleg&cam","mt":["RAW","VIDEO"],"ip":true,"of":false,"a":"ars1juz1456bluxz","pe":[]},{"id":2,"p":3.141592653589793,"n":"Интересные фото \uD83C\uDF55","q":"","mt":null,"ip":false,"of":false,"a":null,"pe":["p2132523232"]},{"id":3,"p":25.5,"n":"media types empty","q":"","mt":[],"ip":false,"of":true,"a":null,"pe":["p2132523232","pwr9hh8ef9w3"]}]}}""",
+            """{"v":4,"d":{"b":[{"id":1,"p":1.0,"n":"My camera","q":"quality:3 oleg&cam","mt":["RAW","VIDEO"],"ip":true,"of":false,"a":"ars1juz1456bluxz","pe":[],"po":"ALL"},{"id":2,"p":3.141592653589793,"n":"Интересные фото \uD83C\uDF55","q":"","mt":null,"ip":false,"of":false,"a":null,"pe":["p2132523232"],"po":"ALL"},{"id":3,"p":25.5,"n":"media types empty","q":"","mt":[],"ip":false,"of":true,"a":null,"pe":["p2132523232","pwr9hh8ef9w3"],"po":"ANY"}]}}""",
             outputJson,
         )
     }
@@ -102,7 +111,7 @@ class JsonSearchBookmarkBackupTest : KoinComponent {
         val backup = getKoin().get<JsonSearchBookmarksBackup>()
 
         val inputJson =
-            """{"v":3,"d":{"b":[{"id":1,"p":1.0,"n":"My camera","q":"quality:3 oleg&cam","mt":["RAW","VIDEO"],"ip":true,"of":false,"a":"ars1juz1456bluxz","pe":[]},{"id":2,"p":3.141592653589793,"n":"Интересные фото \uD83C\uDF55","q":"","mt":null,"ip":false,"of":false,"a":null,"pe":["p2132523232"]},{"id":3,"p":25.5,"n":"media types empty","q":"","mt":[],"ip":false,"of":true,"a":null,"pe":["p2132523232","pwr9hh8ef9w3"]}]}}"""
+            """{"v":4,"d":{"b":[{"id":1,"p":1.0,"n":"My camera","q":"quality:3 oleg&cam","mt":["RAW","VIDEO"],"ip":true,"of":false,"a":"ars1juz1456bluxz","pe":[],"po":"ALL"},{"id":2,"p":3.141592653589793,"n":"Интересные фото \uD83C\uDF55","q":"","mt":null,"ip":false,"of":false,"a":null,"pe":["p2132523232"],"po":"ALL"},{"id":3,"p":25.5,"n":"media types empty","q":"","mt":[],"ip":false,"of":true,"a":null,"pe":["p2132523232","pwr9hh8ef9w3"],"po":"ANY"}]}}"""
         val inputStream = inputJson.byteInputStream(Charsets.UTF_8)
         val imported = backup.readBackup(inputStream)
 
@@ -123,6 +132,40 @@ class JsonSearchBookmarkBackupTest : KoinComponent {
             // equals can be used to check all the fields.
             Assert.assertEquals(bookmark.searchConfig, importedBookmark.searchConfig)
             println(bookmark.searchConfig.copy()) // Test for data class – .copy exists.
+        }
+    }
+
+    @Test
+    fun importV3() {
+        val backup = getKoin().get<JsonSearchBookmarksBackup>()
+
+        val inputJson =
+            """{"v":3,"d":{"b":[{"id":1,"p":1.0,"n":"My camera","q":"quality:3 oleg&cam","mt":["RAW","VIDEO"],"ip":true,"of":false,"a":"ars1juz1456bluxz","pe":[]},{"id":2,"p":3.141592653589793,"n":"Интересные фото \uD83C\uDF55","q":"","mt":null,"ip":false,"of":false,"a":null,"pe":["p2132523232"]},{"id":3,"p":25.5,"n":"media types empty","q":"","mt":[],"ip":false,"of":true,"a":null,"pe":["p2132523232","pwr9hh8ef9w3"]}]}}"""
+        val inputStream = inputJson.byteInputStream(Charsets.UTF_8)
+        val imported = backup.readBackup(inputStream)
+
+        Assert.assertEquals(
+            BOOKMARKS.size,
+            imported.size,
+        )
+
+        BOOKMARKS.forEachIndexed { i, bookmark ->
+            val importedBookmark = imported[i]
+            val expectedBookmark = bookmark.copy(
+                searchConfig = bookmark.searchConfig.copy(
+                    personFilterOperator = SearchConfig.PersonFilterOperator.ALL,
+                )
+            )
+
+            Assert.assertEquals(expectedBookmark, importedBookmark)
+
+            Assert.assertEquals(expectedBookmark.position, importedBookmark.position, 0.0)
+            Assert.assertEquals(expectedBookmark.name, importedBookmark.name)
+
+            // As long as the searchConfig is a data class,
+            // equals can be used to check all the fields.
+            Assert.assertEquals(expectedBookmark.searchConfig, importedBookmark.searchConfig)
+            println(expectedBookmark.searchConfig.copy()) // Test for data class – .copy exists.
         }
     }
 

--- a/app/src/test/java/ua/com/radiokot/photoprism/SearchConfigTest.kt
+++ b/app/src/test/java/ua/com/radiokot/photoprism/SearchConfigTest.kt
@@ -43,4 +43,22 @@ class SearchConfigTest {
             SearchConfig.DEFAULT.getPhotoPrismQuery()
         )
     }
+
+    @Test
+    fun shouldBuildQueryWithAnyPersonFilterOperator() {
+        SearchConfig.DEFAULT.copy(
+            personIds = setOf(
+                "s222222222222222",
+                "s333333333333333",
+                "p2222222222222222222222222222222",
+                "p3333333333333333333333333333333",
+            ),
+            personFilterOperator = SearchConfig.PersonFilterOperator.ANY,
+        ).apply {
+            Assert.assertEquals(
+                "public:true subject:s222222222222222|s333333333333333 face:p2222222222222222222222222222222|p3333333333333333333333333333333",
+                getPhotoPrismQuery()
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a People search match operator so selected faces/subjects can be matched by `All` (`&`) or `Any` (`|`).
- Wires the operator into the mobile search People section and keeps `All` as the default for existing behavior.
- Persists the operator through current search prefs, search bookmarks, JSON backup/import, and the Room bookmarks schema.

This came from a real mobile workflow, not just an isolated code change. I built a debug APK, sideloaded it onto my Pixel 9a, connected it to my existing PhotoPrism library, and manually verified the new toggle in the search screen before opening the PR.

## Screenshots
Live Pixel 9a screenshot from an existing PhotoPrism library:

![Face search operator in live library](https://raw.githubusercontent.com/boscacci/photoprism-android-client/pr-assets/face-search-operator/face-search-operator-live-library.png)

Toggle detail:

![Face search operator toggle crop](https://raw.githubusercontent.com/boscacci/photoprism-android-client/pr-assets/face-search-operator/face-search-operator-toggle-crop.png)

## Validation
- `./gradlew.bat testDebugUnitTest --tests ua.com.radiokot.photoprism.SearchConfigTest --tests ua.com.radiokot.photoprism.JsonSearchBookmarkBackupTest`
- `./gradlew.bat assembleDebug`
- Sideloaded `ua.com.radiokot.photoprism.debug-1.43.0-debug.apk` on a Pixel 9a and manually verified against an existing PhotoPrism library.

Notes:
- `./gradlew.bat lintDebug` still fails on existing unrelated findings in `include_activity_gallery_content.xml:92` (`BottomAppBar`) and `Context.kt:33` (`NewApi`). The new missing-translation lint errors from this change were fixed.
- The full `testDebugUnitTest` suite still hit the existing randomized `SternBrocotTreeSearchTest.extensiveTest` failure locally; the focused feature/storage tests above pass.
